### PR TITLE
Add Dockerfiles for API and web containers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# .NET build artifacts
+bin/
+obj/
+**/bin/
+**/obj/
+
+# Node.js dependencies and build outputs
+node_modules/
+**/node_modules/
+dist/
+**/dist/
+build/
+**/build/
+coverage/
+
+# Test projects (not required in runtime images)
+tests/
+
+# Logs and diagnostics
+*.log
+npm-debug.log*
+yarn-debug.log*
+pnpm-debug.log*
+
+# Environment and IDE settings
+.env
+.env.*
+.vscode/
+.idea/
+*.user
+*.suo
+.DS_Store
+
+# Git metadata
+.git
+.gitignore

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,29 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+
+WORKDIR /src
+
+# copy solution and project files for restore
+COPY AvacareSalesApp.sln ./
+COPY src/Server/Server.csproj src/Server/
+
+RUN dotnet restore src/Server/Server.csproj
+
+# copy the remaining source
+COPY . .
+
+# publish the API to the /app/publish folder
+RUN dotnet publish src/Server/Server.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+
+WORKDIR /app
+
+# configure the ASP.NET Core URL binding and port exposure
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+COPY --from=build /app/publish ./
+
+ENTRYPOINT ["dotnet", "Server.dll"]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,23 @@
+# Build stage
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# Install dependencies using the workspace-aware lockfile
+COPY package.json package-lock.json ./
+COPY web/package.json web/package.json
+
+RUN npm ci
+
+# Copy the rest of the workspace and build the web app
+COPY . .
+RUN npm run build --workspace web
+
+# Runtime stage
+FROM nginx:alpine AS runtime
+
+COPY --from=build /app/web/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -63,3 +63,8 @@ dotnet test
 ### Configuration
 
 Runtime integration with the Sage SDK requires concrete adapter implementations. The default `Sage*Adapter` classes are placeholders that must be completed with real SDK calls and configuration (e.g., connection strings, credentials) before production deployment.
+
+## Container deployment notes
+
+- **API container** – publishes the ASP.NET Core API to `/app/publish` and listens on port `8080`. When deploying to Azure App Service for Containers, set `WEBSITES_PORT=8080` (or the equivalent configuration variable) so the platform forwards traffic correctly.
+- **Web container** – serves the static frontend bundle from NGINX on port `80`, ready to sit behind an ingress controller or Application Gateway without additional port remapping.


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile for the ASP.NET Core API that publishes to `/app/publish` and listens on port 8080
- add a Node 20 + nginx Dockerfile for the web workspace and reduce build context with a `.dockerignore`
- document the container port expectations in the README deployment notes

## Testing
- ⚠️ `dotnet test` *(fails: command not found: dotnet in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0899189a88331b3ae5b58402b50f3