### PR TITLE
Implement identity-backed application user with Sage metadata

### DIFF
--- a/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
+++ b/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
@@ -6,6 +6,6 @@ public class SageAuthAdapter : IAuthAdapter
 {
     public Task<LoginResult> LoginAsync(LoginRequest request, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate with Sage SDK authentication.");
+        throw new NotImplementedException("Integrate with Sage SDK authentication using the supplied Sage customer code.");
     }
 }

--- a/src/Server/Infrastructure/Authentication/ApplicationDbContext.cs
+++ b/src/Server/Infrastructure/Authentication/ApplicationDbContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Server.Infrastructure.Authentication.Models;
+
+namespace Server.Infrastructure.Authentication;
+
+public class ApplicationDbContext : IdentityDbContext<ApplicationUser>
+{
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options)
+        : base(options)
+    {
+    }
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.Entity<ApplicationUser>(entity =>
+        {
+            entity.Property(user => user.SageCustomerCode)
+                .HasMaxLength(64);
+        });
+    }
+}

--- a/src/Server/Infrastructure/Authentication/Migrations/20241004120000_AddIdentitySchema.cs
+++ b/src/Server/Infrastructure/Authentication/Migrations/20241004120000_AddIdentitySchema.cs
@@ -1,0 +1,219 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Server.Infrastructure.Authentication.Migrations;
+
+public partial class AddIdentitySchema : Migration
+{
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "AspNetRoles",
+            columns: table => new
+            {
+                Id = table.Column<string>(type: "TEXT", nullable: false),
+                Name = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                NormalizedName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetRoles", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetUsers",
+            columns: table => new
+            {
+                Id = table.Column<string>(type: "TEXT", nullable: false),
+                UserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                NormalizedUserName = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                Email = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                NormalizedEmail = table.Column<string>(type: "TEXT", maxLength: 256, nullable: true),
+                EmailConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                PasswordHash = table.Column<string>(type: "TEXT", nullable: true),
+                SecurityStamp = table.Column<string>(type: "TEXT", nullable: true),
+                ConcurrencyStamp = table.Column<string>(type: "TEXT", nullable: true),
+                PhoneNumber = table.Column<string>(type: "TEXT", nullable: true),
+                PhoneNumberConfirmed = table.Column<bool>(type: "INTEGER", nullable: false),
+                TwoFactorEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                LockoutEnd = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                LockoutEnabled = table.Column<bool>(type: "INTEGER", nullable: false),
+                AccessFailedCount = table.Column<int>(type: "INTEGER", nullable: false),
+                SageCustomerCode = table.Column<string>(type: "TEXT", maxLength: 64, nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetUsers", x => x.Id);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetRoleClaims",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                RoleId = table.Column<string>(type: "TEXT", nullable: false),
+                ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetRoleClaims", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_AspNetRoleClaims_AspNetRoles_RoleId",
+                    column: x => x.RoleId,
+                    principalTable: "AspNetRoles",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetUserClaims",
+            columns: table => new
+            {
+                Id = table.Column<int>(type: "INTEGER", nullable: false)
+                    .Annotation("Sqlite:Autoincrement", true),
+                UserId = table.Column<string>(type: "TEXT", nullable: false),
+                ClaimType = table.Column<string>(type: "TEXT", nullable: true),
+                ClaimValue = table.Column<string>(type: "TEXT", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetUserClaims", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_AspNetUserClaims_AspNetUsers_UserId",
+                    column: x => x.UserId,
+                    principalTable: "AspNetUsers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetUserLogins",
+            columns: table => new
+            {
+                LoginProvider = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                ProviderKey = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                ProviderDisplayName = table.Column<string>(type: "TEXT", nullable: true),
+                UserId = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetUserLogins", x => new { x.LoginProvider, x.ProviderKey });
+                table.ForeignKey(
+                    name: "FK_AspNetUserLogins_AspNetUsers_UserId",
+                    column: x => x.UserId,
+                    principalTable: "AspNetUsers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetUserRoles",
+            columns: table => new
+            {
+                UserId = table.Column<string>(type: "TEXT", nullable: false),
+                RoleId = table.Column<string>(type: "TEXT", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetUserRoles", x => new { x.UserId, x.RoleId });
+                table.ForeignKey(
+                    name: "FK_AspNetUserRoles_AspNetRoles_RoleId",
+                    column: x => x.RoleId,
+                    principalTable: "AspNetRoles",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+                table.ForeignKey(
+                    name: "FK_AspNetUserRoles_AspNetUsers_UserId",
+                    column: x => x.UserId,
+                    principalTable: "AspNetUsers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateTable(
+            name: "AspNetUserTokens",
+            columns: table => new
+            {
+                UserId = table.Column<string>(type: "TEXT", nullable: false),
+                LoginProvider = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                Name = table.Column<string>(type: "TEXT", maxLength: 128, nullable: false),
+                Value = table.Column<string>(type: "TEXT", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_AspNetUserTokens", x => new { x.UserId, x.LoginProvider, x.Name });
+                table.ForeignKey(
+                    name: "FK_AspNetUserTokens_AspNetUsers_UserId",
+                    column: x => x.UserId,
+                    principalTable: "AspNetUsers",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_AspNetRoleClaims_RoleId",
+            table: "AspNetRoleClaims",
+            column: "RoleId");
+
+        migrationBuilder.CreateIndex(
+            name: "RoleNameIndex",
+            table: "AspNetRoles",
+            column: "NormalizedName",
+            unique: true);
+
+        migrationBuilder.CreateIndex(
+            name: "IX_AspNetUserClaims_UserId",
+            table: "AspNetUserClaims",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_AspNetUserLogins_UserId",
+            table: "AspNetUserLogins",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_AspNetUserRoles_RoleId",
+            table: "AspNetUserRoles",
+            column: "RoleId");
+
+        migrationBuilder.CreateIndex(
+            name: "EmailIndex",
+            table: "AspNetUsers",
+            column: "NormalizedEmail");
+
+        migrationBuilder.CreateIndex(
+            name: "UserNameIndex",
+            table: "AspNetUsers",
+            column: "NormalizedUserName",
+            unique: true);
+    }
+
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "AspNetRoleClaims");
+
+        migrationBuilder.DropTable(
+            name: "AspNetUserClaims");
+
+        migrationBuilder.DropTable(
+            name: "AspNetUserLogins");
+
+        migrationBuilder.DropTable(
+            name: "AspNetUserRoles");
+
+        migrationBuilder.DropTable(
+            name: "AspNetUserTokens");
+
+        migrationBuilder.DropTable(
+            name: "AspNetRoles");
+
+        migrationBuilder.DropTable(
+            name: "AspNetUsers");
+    }
+}

--- a/src/Server/Infrastructure/Authentication/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/src/Server/Infrastructure/Authentication/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -1,0 +1,269 @@
+using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Server.Infrastructure.Authentication.Models;
+
+#nullable disable
+
+namespace Server.Infrastructure.Authentication.Migrations;
+
+[DbContext(typeof(ApplicationDbContext))]
+public partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+{
+    protected override void BuildModel(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasAnnotation("ProductVersion", "8.0.6");
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
+        {
+            b.Property<string>("Id")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("ConcurrencyStamp")
+                .IsConcurrencyToken()
+                .HasColumnType("TEXT");
+
+            b.Property<string>("Name")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("NormalizedName")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("NormalizedName")
+                .IsUnique()
+                .HasDatabaseName("RoleNameIndex");
+
+            b.ToTable("AspNetRoles");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("ClaimType")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("ClaimValue")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("RoleId")
+                .IsRequired()
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("RoleId");
+
+            b.ToTable("AspNetRoleClaims");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+        {
+            b.Property<int>("Id")
+                .ValueGeneratedOnAdd()
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("ClaimType")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("ClaimValue")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("UserId")
+                .IsRequired()
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("UserId");
+
+            b.ToTable("AspNetUserClaims");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+        {
+            b.Property<string>("LoginProvider")
+                .HasMaxLength(128)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("ProviderKey")
+                .HasMaxLength(128)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("ProviderDisplayName")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("UserId")
+                .IsRequired()
+                .HasColumnType("TEXT");
+
+            b.HasKey("LoginProvider", "ProviderKey");
+
+            b.HasIndex("UserId");
+
+            b.ToTable("AspNetUserLogins");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+        {
+            b.Property<string>("UserId")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("RoleId")
+                .HasColumnType("TEXT");
+
+            b.HasKey("UserId", "RoleId");
+
+            b.HasIndex("RoleId");
+
+            b.ToTable("AspNetUserRoles");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+        {
+            b.Property<string>("UserId")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("LoginProvider")
+                .HasMaxLength(128)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("Name")
+                .HasMaxLength(128)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("Value")
+                .HasColumnType("TEXT");
+
+            b.HasKey("UserId", "LoginProvider", "Name");
+
+            b.ToTable("AspNetUserTokens");
+        });
+
+        modelBuilder.Entity("Server.Infrastructure.Authentication.Models.ApplicationUser", b =>
+        {
+            b.Property<string>("Id")
+                .HasColumnType("TEXT");
+
+            b.Property<int>("AccessFailedCount")
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("ConcurrencyStamp")
+                .IsConcurrencyToken()
+                .HasColumnType("TEXT");
+
+            b.Property<string>("Email")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.Property<bool>("EmailConfirmed")
+                .HasColumnType("INTEGER");
+
+            b.Property<bool>("LockoutEnabled")
+                .HasColumnType("INTEGER");
+
+            b.Property<DateTimeOffset?>("LockoutEnd")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("NormalizedEmail")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("NormalizedUserName")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("PasswordHash")
+                .HasColumnType("TEXT");
+
+            b.Property<string>("PhoneNumber")
+                .HasColumnType("TEXT");
+
+            b.Property<bool>("PhoneNumberConfirmed")
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("SageCustomerCode")
+                .IsRequired()
+                .HasMaxLength(64)
+                .HasColumnType("TEXT");
+
+            b.Property<string>("SecurityStamp")
+                .HasColumnType("TEXT");
+
+            b.Property<bool>("TwoFactorEnabled")
+                .HasColumnType("INTEGER");
+
+            b.Property<string>("UserName")
+                .HasMaxLength(256)
+                .HasColumnType("TEXT");
+
+            b.HasKey("Id");
+
+            b.HasIndex("NormalizedEmail")
+                .HasDatabaseName("EmailIndex");
+
+            b.HasIndex("NormalizedUserName")
+                .IsUnique()
+                .HasDatabaseName("UserNameIndex");
+
+            b.ToTable("AspNetUsers");
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<string>", b =>
+        {
+            b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                .WithMany()
+                .HasForeignKey("RoleId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserClaim<string>", b =>
+        {
+            b.HasOne("Server.Infrastructure.Authentication.Models.ApplicationUser", null)
+                .WithMany()
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<string>", b =>
+        {
+            b.HasOne("Server.Infrastructure.Authentication.Models.ApplicationUser", null)
+                .WithMany()
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserRole<string>", b =>
+        {
+            b.HasOne("Microsoft.AspNetCore.Identity.IdentityRole", null)
+                .WithMany()
+                .HasForeignKey("RoleId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+
+            b.HasOne("Server.Infrastructure.Authentication.Models.ApplicationUser", null)
+                .WithMany()
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+
+        modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserToken<string>", b =>
+        {
+            b.HasOne("Server.Infrastructure.Authentication.Models.ApplicationUser", null)
+                .WithMany()
+                .HasForeignKey("UserId")
+                .OnDelete(DeleteBehavior.Cascade)
+                .IsRequired();
+        });
+    }
+}

--- a/src/Server/Infrastructure/Authentication/Models/ApplicationUser.cs
+++ b/src/Server/Infrastructure/Authentication/Models/ApplicationUser.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+
+namespace Server.Infrastructure.Authentication.Models;
+
+public class ApplicationUser : IdentityUser
+{
+    public string SageCustomerCode { get; set; } = string.Empty;
+}

--- a/src/Server/Infrastructure/Authentication/Models/LoginRequest.cs
+++ b/src/Server/Infrastructure/Authentication/Models/LoginRequest.cs
@@ -1,3 +1,3 @@
 namespace Server.Infrastructure.Authentication.Models;
 
-public record LoginRequest(string Username, string Password);
+public record LoginRequest(string Username, string Password, string? SageCustomerCode = null);

--- a/src/Server/Infrastructure/Authentication/Models/LoginResult.cs
+++ b/src/Server/Infrastructure/Authentication/Models/LoginResult.cs
@@ -1,3 +1,3 @@
 namespace Server.Infrastructure.Authentication.Models;
 
-public record LoginResult(string Username, string Token);
+public record LoginResult(string Username, string Token, string SageCustomerCode);

--- a/src/Server/Infrastructure/Authentication/Models/RegisterRequest.cs
+++ b/src/Server/Infrastructure/Authentication/Models/RegisterRequest.cs
@@ -1,0 +1,3 @@
+namespace Server.Infrastructure.Authentication.Models;
+
+public record RegisterRequest(string Username, string Password, string SageCustomerCode, string? Email = null);

--- a/src/Server/Infrastructure/Authentication/Models/RegistrationResult.cs
+++ b/src/Server/Infrastructure/Authentication/Models/RegistrationResult.cs
@@ -1,0 +1,3 @@
+namespace Server.Infrastructure.Authentication.Models;
+
+public record RegistrationResult(string UserId, string Username, string SageCustomerCode);

--- a/src/Server/Infrastructure/Authentication/Services/AuthService.cs
+++ b/src/Server/Infrastructure/Authentication/Services/AuthService.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Server.Common.Exceptions;
 using Server.Infrastructure.Authentication.Adapters;
@@ -13,11 +14,13 @@ public interface IAuthService
 public class AuthService : IAuthService
 {
     private readonly IAuthAdapter _authAdapter;
+    private readonly UserManager<ApplicationUser> _userManager;
     private readonly ILogger<AuthService> _logger;
 
-    public AuthService(IAuthAdapter authAdapter, ILogger<AuthService> logger)
+    public AuthService(IAuthAdapter authAdapter, UserManager<ApplicationUser> userManager, ILogger<AuthService> logger)
     {
         _authAdapter = authAdapter;
+        _userManager = userManager;
         _logger = logger;
     }
 
@@ -25,7 +28,28 @@ public class AuthService : IAuthService
     {
         try
         {
-            return await _authAdapter.LoginAsync(request, cancellationToken);
+            var user = await _userManager.FindByNameAsync(request.Username);
+            if (user is null)
+            {
+                _logger.LogWarning("Login failed - user {Username} not found", request.Username);
+                throw new DomainException("Invalid username or password.");
+            }
+
+            var passwordValid = await _userManager.CheckPasswordAsync(user, request.Password);
+            if (!passwordValid)
+            {
+                _logger.LogWarning("Login failed - invalid password for user {Username}", request.Username);
+                throw new DomainException("Invalid username or password.");
+            }
+
+            var adapterRequest = request with { SageCustomerCode = user.SageCustomerCode };
+            var result = await _authAdapter.LoginAsync(adapterRequest, cancellationToken);
+
+            return result with { SageCustomerCode = user.SageCustomerCode };
+        }
+        catch (DomainException)
+        {
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/Server/Infrastructure/Authentication/Services/UserOnboardingService.cs
+++ b/src/Server/Infrastructure/Authentication/Services/UserOnboardingService.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Server.Common.Exceptions;
+using Server.Infrastructure.Authentication.Models;
+
+namespace Server.Infrastructure.Authentication.Services;
+
+public interface IUserOnboardingService
+{
+    Task<RegistrationResult> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken);
+}
+
+public class UserOnboardingService : IUserOnboardingService
+{
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly ILogger<UserOnboardingService> _logger;
+
+    public UserOnboardingService(UserManager<ApplicationUser> userManager, ILogger<UserOnboardingService> logger)
+    {
+        _userManager = userManager;
+        _logger = logger;
+    }
+
+    public async Task<RegistrationResult> RegisterAsync(RegisterRequest request, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(request.SageCustomerCode))
+        {
+            throw new DomainException("Sage customer code is required.");
+        }
+
+        var existingUser = await _userManager.FindByNameAsync(request.Username);
+        if (existingUser is not null)
+        {
+            throw new DomainException("A user with the provided username already exists.");
+        }
+
+        var user = new ApplicationUser
+        {
+            UserName = request.Username,
+            Email = request.Email,
+            SageCustomerCode = request.SageCustomerCode
+        };
+
+        var identityResult = await _userManager.CreateAsync(user, request.Password);
+        if (!identityResult.Succeeded)
+        {
+            var errors = string.Join(", ", identityResult.Errors.Select(error => error.Description));
+            _logger.LogWarning("Failed to register user {Username}: {Errors}", request.Username, errors);
+            throw new DomainException($"Failed to create user: {errors}");
+        }
+
+        _logger.LogInformation("Registered user {Username} with Sage customer code {SageCustomerCode}", request.Username, request.SageCustomerCode);
+
+        return new RegistrationResult(user.Id, user.UserName!, user.SageCustomerCode);
+    }
+}

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -1,4 +1,8 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Server.Infrastructure.Authentication;
 using Server.Infrastructure.Authentication.Adapters;
+using Server.Infrastructure.Authentication.Models;
 using Server.Infrastructure.Authentication.Services;
 using Server.Infrastructure.Database;
 using Server.Transactions.AccountsReceivable.Adapters;
@@ -14,10 +18,23 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+var connectionString = builder.Configuration.GetConnectionString("DefaultConnection") ?? "Data Source=avacare.db";
+
+builder.Services.AddDbContext<ApplicationDbContext>(options =>
+    options.UseSqlite(connectionString));
+
+builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
+    {
+        options.User.RequireUniqueEmail = false;
+    })
+    .AddEntityFrameworkStores<ApplicationDbContext>()
+    .AddDefaultTokenProviders();
+
 builder.Services.AddScoped<IDatabaseContext, DatabaseContext>();
 
 builder.Services.AddScoped<IAuthAdapter, SageAuthAdapter>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IUserOnboardingService, UserOnboardingService>();
 
 builder.Services.AddScoped<ICustomerAdapter, SageCustomerAdapter>();
 builder.Services.AddScoped<ICustomerService, CustomerService>();

--- a/src/Server/Server.csproj
+++ b/src/Server/Server.csproj
@@ -8,6 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.20" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.20" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.20">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.20" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/src/Server/appsettings.Development.json
+++ b/src/Server/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=avacare.dev.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/src/Server/appsettings.json
+++ b/src/Server/appsettings.json
@@ -1,4 +1,7 @@
 {
+  "ConnectionStrings": {
+    "DefaultConnection": "Data Source=avacare.db"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/tests/Server.Tests/Infrastructure/Authentication/AuthServiceTests.cs
+++ b/tests/Server.Tests/Infrastructure/Authentication/AuthServiceTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Server.Common.Exceptions;
@@ -14,34 +15,81 @@ public class AuthServiceTests
     public async Task LoginAsync_DelegatesToAdapter()
     {
         var adapter = new Mock<IAuthAdapter>();
+        var userManager = CreateUserManagerMock();
         var logger = Mock.Of<ILogger<AuthService>>();
         var request = new LoginRequest("user", "password");
-        var expected = new LoginResult("user", "token");
+        var expected = new LoginResult("user", "token", "CUST001");
+        var user = new ApplicationUser
+        {
+            UserName = request.Username,
+            SageCustomerCode = "CUST001"
+        };
 
-        adapter.Setup(a => a.LoginAsync(request, It.IsAny<CancellationToken>()))
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync(user);
+        userManager.Setup(m => m.CheckPasswordAsync(user, request.Password))
+            .ReturnsAsync(true);
+
+        adapter.Setup(a => a.LoginAsync(It.Is<LoginRequest>(r => r.SageCustomerCode == user.SageCustomerCode), It.IsAny<CancellationToken>()))
             .ReturnsAsync(expected);
 
-        var service = new AuthService(adapter.Object, logger);
+        var service = new AuthService(adapter.Object, userManager.Object, logger);
 
         var result = await service.LoginAsync(request, CancellationToken.None);
 
-        result.Should().Be(expected);
+        result.Should().BeEquivalentTo(expected);
     }
 
     [Fact]
     public async Task LoginAsync_WhenAdapterFails_ThrowsDomainException()
     {
         var adapter = new Mock<IAuthAdapter>();
+        var userManager = CreateUserManagerMock();
         var logger = new Mock<ILogger<AuthService>>();
         var request = new LoginRequest("user", "password");
+        var user = new ApplicationUser
+        {
+            UserName = request.Username,
+            SageCustomerCode = "CUST001"
+        };
 
-        adapter.Setup(a => a.LoginAsync(request, It.IsAny<CancellationToken>()))
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync(user);
+        userManager.Setup(m => m.CheckPasswordAsync(user, request.Password))
+            .ReturnsAsync(true);
+
+        adapter.Setup(a => a.LoginAsync(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("boom"));
 
-        var service = new AuthService(adapter.Object, logger.Object);
+        var service = new AuthService(adapter.Object, userManager.Object, logger.Object);
 
         var act = async () => await service.LoginAsync(request, CancellationToken.None);
 
         await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact]
+    public async Task LoginAsync_WhenUserDoesNotExist_ThrowsDomainException()
+    {
+        var adapter = new Mock<IAuthAdapter>();
+        var userManager = CreateUserManagerMock();
+        var logger = new Mock<ILogger<AuthService>>();
+        var request = new LoginRequest("missing", "password");
+
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync((ApplicationUser?)null);
+
+        var service = new AuthService(adapter.Object, userManager.Object, logger.Object);
+
+        var act = async () => await service.LoginAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+        adapter.Verify(a => a.LoginAsync(It.IsAny<LoginRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        return new Mock<UserManager<ApplicationUser>>(store.Object, null!, null!, null!, null!, null!, null!, null!, null!);
     }
 }

--- a/tests/Server.Tests/Infrastructure/Authentication/UserOnboardingServiceTests.cs
+++ b/tests/Server.Tests/Infrastructure/Authentication/UserOnboardingServiceTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Infrastructure.Authentication.Models;
+using Server.Infrastructure.Authentication.Services;
+
+namespace Server.Tests.Infrastructure.Authentication;
+
+public class UserOnboardingServiceTests
+{
+    [Fact]
+    public async Task RegisterAsync_WhenSuccessful_ReturnsRegistrationResult()
+    {
+        var userManager = CreateUserManagerMock();
+        var logger = Mock.Of<ILogger<UserOnboardingService>>();
+        var request = new RegisterRequest("user", "Password123!", "CUST001");
+        ApplicationUser? createdUser = null;
+
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync((ApplicationUser?)null);
+        userManager.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), request.Password))
+            .Callback<ApplicationUser, string>((user, _) => createdUser = user)
+            .ReturnsAsync(IdentityResult.Success);
+
+        var service = new UserOnboardingService(userManager.Object, logger);
+
+        var result = await service.RegisterAsync(request, CancellationToken.None);
+
+        result.Username.Should().Be(request.Username);
+        result.SageCustomerCode.Should().Be(request.SageCustomerCode);
+        createdUser.Should().NotBeNull();
+        createdUser!.SageCustomerCode.Should().Be(request.SageCustomerCode);
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenCustomerCodeMissing_ThrowsDomainException()
+    {
+        var userManager = CreateUserManagerMock();
+        var logger = Mock.Of<ILogger<UserOnboardingService>>();
+        var request = new RegisterRequest("user", "Password123!", " ");
+
+        var service = new UserOnboardingService(userManager.Object, logger);
+
+        var act = async () => await service.RegisterAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenUserExists_ThrowsDomainException()
+    {
+        var userManager = CreateUserManagerMock();
+        var logger = Mock.Of<ILogger<UserOnboardingService>>();
+        var request = new RegisterRequest("user", "Password123!", "CUST001");
+
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync(new ApplicationUser());
+
+        var service = new UserOnboardingService(userManager.Object, logger);
+
+        var act = async () => await service.RegisterAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact]
+    public async Task RegisterAsync_WhenIdentityFails_ThrowsDomainException()
+    {
+        var userManager = CreateUserManagerMock();
+        var logger = Mock.Of<ILogger<UserOnboardingService>>();
+        var request = new RegisterRequest("user", "Password123!", "CUST001");
+
+        userManager.Setup(m => m.FindByNameAsync(request.Username))
+            .ReturnsAsync((ApplicationUser?)null);
+        userManager.Setup(m => m.CreateAsync(It.IsAny<ApplicationUser>(), request.Password))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "boom" }));
+
+        var service = new UserOnboardingService(userManager.Object, logger);
+
+        var act = async () => await service.RegisterAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+
+    private static Mock<UserManager<ApplicationUser>> CreateUserManagerMock()
+    {
+        var store = new Mock<IUserStore<ApplicationUser>>();
+        return new Mock<UserManager<ApplicationUser>>(store.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+    }
+}


### PR DESCRIPTION
## Summary
- add an ApplicationUser type with Sage customer code support and register an EF Core Identity DbContext plus migrations
- extend onboarding and authentication flows to capture Sage customer codes and surface them to the client
- update DTOs, services, and unit tests to enforce the customer code requirement and validate the new behavior

## Testing
- dotnet format
- dotnet test


------
https://chatgpt.com/codex/tasks/task_e_68d088a7cfd4833189684d391c91cf71