### PR TITLE
Add database provisioning guidance and sanitize dev settings

### DIFF
--- a/src/Server/appsettings.Development.json
+++ b/src/Server/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "Default": "Server=localhost,1433;Database=AvacareSalesApp;User Id=sa;Password=YourStrong!Passw0rd;TrustServerCertificate=True"
+    "Default": ""
   }
 }


### PR DESCRIPTION
## Summary
- document how to provision SQL Server locally or remotely, create the AvacareSalesApp database, and configure credentials securely
- describe the repeatable Entity Framework Core command that materialises the Identity schema before the API starts
- blank the checked-in development connection string so developers rely on secrets or environment variables

## Testing
- ❌ `dotnet test` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d092c1688c8331bdac25df9277881d