### PR TITLE
sage: add in-memory sdk adapters and tests

### DIFF
--- a/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
+++ b/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
@@ -1,4 +1,6 @@
+using Server.Common.Exceptions;
 using Server.Infrastructure.Authentication.Models;
+using Server.Sage;
 
 namespace Server.Infrastructure.Authentication.Adapters;
 
@@ -6,6 +8,14 @@ public class SageAuthAdapter : IAuthAdapter
 {
     public Task<LoginResult> LoginAsync(LoginRequest request, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate with Sage SDK authentication.");
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (SageSdkStub.TryLogin(request.Username, request.Password, out var result))
+        {
+            return Task.FromResult(result);
+        }
+
+        throw new DomainException("Invalid Sage credentials supplied.");
     }
 }

--- a/src/Server/Sage/SageSdkStub.cs
+++ b/src/Server/Sage/SageSdkStub.cs
@@ -1,0 +1,177 @@
+using System.Text;
+using Server.Common.Exceptions;
+using Server.Infrastructure.Authentication.Models;
+using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.Inventory.Models;
+using Server.Transactions.OrderEntry.Models;
+
+namespace Server.Sage;
+
+/// <summary>
+/// Provides a deterministic, in-memory representation of the Sage SDK so the
+/// application can be exercised without the real integration during tests or demos.
+/// </summary>
+public static class SageSdkStub
+{
+    private static readonly object SyncRoot = new();
+
+    private static readonly Dictionary<string, (string Password, string TokenSeed)> UserSeed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["demo"] = ("P@ssw0rd!", "demo-token"),
+        ["sales"] = ("Sales123!", "sales-token")
+    };
+
+    private static readonly Dictionary<string, Customer> CustomerSeed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["100"] = new Customer("100", "Acme Corporation", "accounts@acme.test", 15_000m),
+        ["200"] = new Customer("200", "Globex Corporation", "billing@globex.test", 25_000m)
+    };
+
+    private static readonly Dictionary<string, Product> ProductSeed = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["PROD-001"] = new Product("PROD-001", "Widget", "Standard widget", 49.99m, 50),
+        ["PROD-002"] = new Product("PROD-002", "Gadget", "Advanced gadget", 99.50m, 25),
+        ["PROD-003"] = new Product("PROD-003", "Doohickey", "Multi-purpose tool", 149.00m, 10)
+    };
+
+    private static readonly Dictionary<string, (string Password, string TokenSeed)> Users = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, Customer> Customers = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, Product> Products = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, Invoice> Invoices = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, Payment> Payments = new(StringComparer.OrdinalIgnoreCase);
+    private static readonly Dictionary<string, SalesOrder> Orders = new(StringComparer.OrdinalIgnoreCase);
+
+    static SageSdkStub()
+    {
+        Reset();
+    }
+
+    public static void Reset()
+    {
+        lock (SyncRoot)
+        {
+            Users.Clear();
+            foreach (var (username, entry) in UserSeed)
+            {
+                Users[username] = entry;
+            }
+
+            Customers.Clear();
+            foreach (var (id, customer) in CustomerSeed)
+            {
+                Customers[id] = customer;
+            }
+
+            Products.Clear();
+            foreach (var (id, product) in ProductSeed)
+            {
+                Products[id] = product;
+            }
+
+            Invoices.Clear();
+            Payments.Clear();
+            Orders.Clear();
+        }
+    }
+
+    public static bool TryLogin(string username, string password, out LoginResult result)
+    {
+        lock (SyncRoot)
+        {
+            if (Users.TryGetValue(username, out var credentials) && credentials.Password == password)
+            {
+                var tokenPayload = Encoding.UTF8.GetBytes($"{username}:{credentials.TokenSeed}");
+                result = new LoginResult(username, Convert.ToBase64String(tokenPayload));
+                return true;
+            }
+
+            result = default!;
+            return false;
+        }
+    }
+
+    public static Customer? FindCustomer(string customerId)
+    {
+        lock (SyncRoot)
+        {
+            return Customers.TryGetValue(customerId, out var customer) ? customer : null;
+        }
+    }
+
+    public static Invoice SaveInvoice(Invoice invoice)
+    {
+        lock (SyncRoot)
+        {
+            if (!Customers.ContainsKey(invoice.CustomerId))
+            {
+                throw new DomainException($"Customer {invoice.CustomerId} does not exist in Sage.");
+            }
+
+            var posted = invoice with { Status = "Posted" };
+            Invoices[posted.Id] = posted;
+            return posted;
+        }
+    }
+
+    public static Payment SavePayment(Payment payment)
+    {
+        lock (SyncRoot)
+        {
+            if (!Invoices.ContainsKey(payment.InvoiceId))
+            {
+                throw new DomainException($"Invoice {payment.InvoiceId} was not found in Sage.");
+            }
+
+            Payments[payment.Id] = payment;
+            return payment;
+        }
+    }
+
+    public static IReadOnlyCollection<Product> GetProducts()
+    {
+        lock (SyncRoot)
+        {
+            return Products.Values.Select(product => product with { }).ToArray();
+        }
+    }
+
+    public static SalesOrder SaveOrder(SalesOrder order)
+    {
+        lock (SyncRoot)
+        {
+            if (!Customers.ContainsKey(order.CustomerId))
+            {
+                throw new DomainException($"Customer {order.CustomerId} does not exist in Sage.");
+            }
+
+            foreach (var line in order.Lines)
+            {
+                if (!Products.TryGetValue(line.ProductId, out var product))
+                {
+                    throw new DomainException($"Product {line.ProductId} does not exist in Sage.");
+                }
+
+                if (line.Quantity <= 0)
+                {
+                    throw new DomainException($"Quantity for {line.ProductId} must be greater than zero.");
+                }
+
+                var quantity = (int)line.Quantity;
+                if (line.Quantity != quantity)
+                {
+                    throw new DomainException($"Fractional quantities are not supported for {line.ProductId} in the stub.");
+                }
+
+                if (quantity > product.QuantityOnHand)
+                {
+                    throw new DomainException($"Insufficient stock for {line.ProductId}.");
+                }
+
+                Products[line.ProductId] = product with { QuantityOnHand = product.QuantityOnHand - quantity };
+            }
+
+            Orders[order.Id] = order;
+            return order;
+        }
+    }
+}

--- a/src/Server/Transactions/AccountsReceivable/Adapters/SageCustomerAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SageCustomerAdapter.cs
@@ -1,4 +1,5 @@
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Sage;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
@@ -6,6 +7,9 @@ public class SageCustomerAdapter : ICustomerAdapter
 {
     public Task<Customer?> GetCustomerAsync(string customerId, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate customer retrieval with Sage SDK.");
+        ArgumentException.ThrowIfNullOrWhiteSpace(customerId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(SageSdkStub.FindCustomer(customerId));
     }
 }

--- a/src/Server/Transactions/AccountsReceivable/Adapters/SageInvoiceAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SageInvoiceAdapter.cs
@@ -1,4 +1,5 @@
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Sage;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
@@ -6,6 +7,9 @@ public class SageInvoiceAdapter : IInvoiceAdapter
 {
     public Task<Invoice> CreateInvoiceAsync(Invoice invoice, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate invoice creation with Sage SDK.");
+        ArgumentNullException.ThrowIfNull(invoice);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(SageSdkStub.SaveInvoice(invoice));
     }
 }

--- a/src/Server/Transactions/AccountsReceivable/Adapters/SagePaymentAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SagePaymentAdapter.cs
@@ -1,4 +1,5 @@
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Sage;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
@@ -6,6 +7,9 @@ public class SagePaymentAdapter : IPaymentAdapter
 {
     public Task<Payment> ApplyPaymentAsync(Payment payment, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate payment posting with Sage SDK.");
+        ArgumentNullException.ThrowIfNull(payment);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(SageSdkStub.SavePayment(payment));
     }
 }

--- a/src/Server/Transactions/Inventory/Adapters/SageProductAdapter.cs
+++ b/src/Server/Transactions/Inventory/Adapters/SageProductAdapter.cs
@@ -1,4 +1,5 @@
 using Server.Transactions.Inventory.Models;
+using Server.Sage;
 
 namespace Server.Transactions.Inventory.Adapters;
 
@@ -6,6 +7,7 @@ public class SageProductAdapter : IProductAdapter
 {
     public Task<IReadOnlyCollection<Product>> GetProductsAsync(CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate product retrieval with Sage SDK.");
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(SageSdkStub.GetProducts());
     }
 }

--- a/src/Server/Transactions/OrderEntry/Adapters/SageOrderEntryAdapter.cs
+++ b/src/Server/Transactions/OrderEntry/Adapters/SageOrderEntryAdapter.cs
@@ -1,4 +1,5 @@
 using Server.Transactions.OrderEntry.Models;
+using Server.Sage;
 
 namespace Server.Transactions.OrderEntry.Adapters;
 
@@ -6,6 +7,9 @@ public class SageOrderEntryAdapter : IOrderEntryAdapter
 {
     public Task<SalesOrder> CreateOrderAsync(SalesOrder order, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate order creation with Sage SDK.");
+        ArgumentNullException.ThrowIfNull(order);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        return Task.FromResult(SageSdkStub.SaveOrder(order));
     }
 }

--- a/tests/Server.Tests/Integration/SageAdaptersIntegrationTests.cs
+++ b/tests/Server.Tests/Integration/SageAdaptersIntegrationTests.cs
@@ -1,0 +1,214 @@
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Server.Controllers;
+using Server.Infrastructure.Authentication.Adapters;
+using Server.Infrastructure.Authentication.Models;
+using Server.Infrastructure.Authentication.Services;
+using Server.Infrastructure.Database;
+using Server.Sage;
+using Server.Transactions.AccountsReceivable.Adapters;
+using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Services;
+using Server.Transactions.Inventory.Adapters;
+using Server.Transactions.Inventory.Models;
+using Server.Transactions.Inventory.Services;
+using Server.Transactions.OrderEntry.Adapters;
+using Server.Transactions.OrderEntry.Models;
+using Server.Transactions.OrderEntry.Services;
+
+namespace Server.Tests.Integration;
+
+public class SageAdaptersIntegrationTests
+{
+    private static readonly DateTime SampleDate = new(2024, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+
+    [Fact]
+    public async Task AuthController_WithValidCredentials_ReturnsToken()
+    {
+        SageSdkStub.Reset();
+
+        var controller = BuildAuthController(out var databaseContext);
+        var result = await controller.Login(new LoginRequest("demo", "P@ssw0rd!"), CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var login = okResult.Value.Should().BeOfType<LoginResult>().Subject;
+        login.Username.Should().Be("demo");
+        login.Token.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task CustomersController_WithExistingCustomer_ReturnsCustomer()
+    {
+        SageSdkStub.Reset();
+
+        var controller = BuildCustomersController(out var databaseContext);
+        var response = await controller.GetCustomer("100", CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().BeEquivalentTo(new Customer("100", "Acme Corporation", "accounts@acme.test", 15_000m));
+    }
+
+    [Fact]
+    public async Task InvoicesController_WhenPostingInvoice_ReturnsPostedInvoice()
+    {
+        SageSdkStub.Reset();
+
+        var controller = BuildInvoicesController(out var databaseContext);
+        var request = new CreateInvoiceRequest("100", 1250m, SampleDate, "Draft");
+
+        var response = await controller.CreateInvoice(request, CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var invoice = okResult.Value.Should().BeOfType<Invoice>().Subject;
+        invoice.CustomerId.Should().Be("100");
+        invoice.Amount.Should().Be(1250m);
+        invoice.Status.Should().Be("Posted");
+    }
+
+    [Fact]
+    public async Task PaymentsController_WhenApplyingPayment_ReturnsPayment()
+    {
+        SageSdkStub.Reset();
+
+        var invoicesController = BuildInvoicesController(out _);
+        var invoiceResponse = await invoicesController.CreateInvoice(
+            new CreateInvoiceRequest("100", 500m, SampleDate, "Draft"),
+            CancellationToken.None);
+        var invoiceResult = invoiceResponse.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var invoice = invoiceResult.Value.Should().BeOfType<Invoice>().Subject;
+
+        var paymentsController = BuildPaymentsController(out var databaseContext);
+        var paymentRequest = new ApplyPaymentRequest(invoice.Id, 200m, SampleDate.AddDays(1));
+
+        var paymentResponse = await paymentsController.ApplyPayment(paymentRequest, CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = paymentResponse.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var payment = okResult.Value.Should().BeOfType<Payment>().Subject;
+        payment.InvoiceId.Should().Be(invoice.Id);
+        payment.Amount.Should().Be(200m);
+    }
+
+    [Fact]
+    public async Task ProductsController_ReturnsInventorySnapshot()
+    {
+        SageSdkStub.Reset();
+
+        var controller = BuildProductsController(out var databaseContext);
+        var response = await controller.GetProducts(CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var products = okResult.Value.Should().BeAssignableTo<IReadOnlyCollection<Product>>().Subject;
+        products.Should().Contain(p => p.Id == "PROD-001" && p.QuantityOnHand == 50);
+    }
+
+    [Fact]
+    public async Task OrdersController_WhenCreatingOrder_AdjustsInventory()
+    {
+        SageSdkStub.Reset();
+
+        var controller = BuildOrdersController(out var databaseContext);
+        var orderRequest = new CreateOrderRequest(
+            "100",
+            SampleDate,
+            new[] { new SalesOrderLine("PROD-001", 2m, 49.99m) });
+
+        var response = await controller.CreateOrder(orderRequest, CancellationToken.None);
+
+        databaseContext.BeginCount.Should().Be(1);
+        databaseContext.CommitCount.Should().Be(1);
+        databaseContext.RollbackCount.Should().Be(0);
+
+        var okResult = response.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var order = okResult.Value.Should().BeOfType<SalesOrder>().Subject;
+        order.CustomerId.Should().Be("100");
+        order.Lines.Should().ContainSingle(line => line.ProductId == "PROD-001" && line.Quantity == 2m);
+
+        var productsController = BuildProductsController(out _);
+        var productsResult = await productsController.GetProducts(CancellationToken.None);
+        var productsOk = productsResult.Result.Should().BeOfType<OkObjectResult>().Subject;
+        var products = productsOk.Value.Should().BeAssignableTo<IReadOnlyCollection<Product>>().Subject;
+        products.Should().Contain(p => p.Id == "PROD-001" && p.QuantityOnHand == 48);
+    }
+
+    private static AuthController BuildAuthController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SageAuthAdapter();
+        var service = new AuthService(adapter, NullLogger<AuthService>.Instance);
+        return new AuthController(service, databaseContext, NullLogger<AuthController>.Instance);
+    }
+
+    private static CustomersController BuildCustomersController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SageCustomerAdapter();
+        var service = new CustomerService(adapter, NullLogger<CustomerService>.Instance);
+        return new CustomersController(service, databaseContext, NullLogger<CustomersController>.Instance);
+    }
+
+    private static InvoicesController BuildInvoicesController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SageInvoiceAdapter();
+        var service = new InvoiceService(adapter, NullLogger<InvoiceService>.Instance);
+        return new InvoicesController(service, databaseContext, NullLogger<InvoicesController>.Instance);
+    }
+
+    private static PaymentsController BuildPaymentsController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SagePaymentAdapter();
+        var service = new PaymentService(adapter, NullLogger<PaymentService>.Instance);
+        return new PaymentsController(service, databaseContext, NullLogger<PaymentsController>.Instance);
+    }
+
+    private static ProductsController BuildProductsController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SageProductAdapter();
+        var service = new ProductService(adapter, NullLogger<ProductService>.Instance);
+        return new ProductsController(service, databaseContext, NullLogger<ProductsController>.Instance);
+    }
+
+    private static OrdersController BuildOrdersController(out FakeDatabaseContext databaseContext)
+    {
+        databaseContext = new FakeDatabaseContext();
+        var adapter = new SageOrderEntryAdapter();
+        var service = new OrderService(adapter, NullLogger<OrderService>.Instance);
+        return new OrdersController(service, databaseContext, NullLogger<OrdersController>.Instance);
+    }
+
+    private sealed class FakeDatabaseContext : IDatabaseContext
+    {
+        public int BeginCount { get; private set; }
+        public int CommitCount { get; private set; }
+        public int RollbackCount { get; private set; }
+
+        public void BeginTran() => BeginCount++;
+
+        public void CommitTran() => CommitCount++;
+
+        public void RollbackTran() => RollbackCount++;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce a deterministic SageSdkStub that simulates users, customers, inventory, invoices, payments, and orders
- update all Sage adapters to authenticate and persist data through the shared stub instead of throwing
- add integration-style controller tests that exercise the adapters and confirm usable responses

## Testing
- ❌ `dotnet test` *(command unavailable: dotnet CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d092cf9cc083318a581a09ef0260e0