### PR TITLE
database: wrap sage transaction session

### DIFF
--- a/src/Server/Infrastructure/Database/DatabaseContext.cs
+++ b/src/Server/Infrastructure/Database/DatabaseContext.cs
@@ -1,50 +1,170 @@
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Server.Common.Exceptions;
 
 namespace Server.Infrastructure.Database;
 
 public class DatabaseContext : IDatabaseContext
 {
     private readonly ILogger<DatabaseContext> _logger;
-    private bool _transactionStarted;
+    private readonly ISageSessionFactory _sessionFactory;
+    private readonly SageSessionOptions _options;
+    private ISageSession? _session;
+    private ISageTransaction? _transaction;
+    private bool _branchApplied;
 
-    public DatabaseContext(ILogger<DatabaseContext> logger)
+    public DatabaseContext(
+        ILogger<DatabaseContext> logger,
+        ISageSessionFactory sessionFactory,
+        IOptions<SageSessionOptions> options)
     {
         _logger = logger;
+        _sessionFactory = sessionFactory;
+        _options = options.Value;
     }
 
     public void BeginTran()
     {
-        if (_transactionStarted)
+        if (_transaction != null)
         {
             _logger.LogWarning("BeginTran called while a transaction is already active.");
             return;
         }
 
-        _logger.LogDebug("Starting database transaction.");
-        _transactionStarted = true;
+        try
+        {
+            _logger.LogDebug("Starting Sage SDK database transaction.");
+            var session = EnsureSession();
+            _transaction = session.BeginTransaction();
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to begin Sage SDK transaction.");
+            throw new DomainException("Unable to begin a Sage SDK transaction.", ex);
+        }
     }
 
     public void CommitTran()
     {
-        if (!_transactionStarted)
+        if (_transaction == null)
         {
             _logger.LogWarning("CommitTran called without an active transaction.");
             return;
         }
 
-        _logger.LogDebug("Committing database transaction.");
-        _transactionStarted = false;
+        try
+        {
+            _logger.LogDebug("Committing Sage SDK transaction.");
+            _transaction.Commit();
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to commit Sage SDK transaction.");
+            throw new DomainException("Unable to commit the Sage SDK transaction.", ex);
+        }
+        finally
+        {
+            CleanupTransaction();
+        }
     }
 
     public void RollbackTran()
     {
-        if (!_transactionStarted)
+        if (_transaction == null)
         {
             _logger.LogWarning("RollbackTran called without an active transaction.");
             return;
         }
 
-        _logger.LogDebug("Rolling back database transaction.");
-        _transactionStarted = false;
+        try
+        {
+            _logger.LogDebug("Rolling back Sage SDK transaction.");
+            _transaction.Rollback();
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to roll back Sage SDK transaction.");
+            throw new DomainException("Unable to roll back the Sage SDK transaction.", ex);
+        }
+        finally
+        {
+            CleanupTransaction();
+        }
+    }
+
+    private ISageSession EnsureSession()
+    {
+        _session ??= _sessionFactory.CreateSession();
+
+        if (!_session.IsConnected)
+        {
+            _session.Connect();
+            _branchApplied = false;
+        }
+
+        if (!_branchApplied)
+        {
+            var branchCode = _options.BranchCode;
+            if (!string.IsNullOrWhiteSpace(branchCode))
+            {
+                _session.SetBranch(branchCode);
+            }
+
+            _branchApplied = true;
+        }
+
+        return _session;
+    }
+
+    private void CleanupTransaction()
+    {
+        if (_transaction != null)
+        {
+            try
+            {
+                _transaction.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to dispose Sage SDK transaction.");
+            }
+            finally
+            {
+                _transaction = null;
+            }
+        }
+
+        if (_session != null)
+        {
+            try
+            {
+                if (_session.IsConnected)
+                {
+                    _session.Disconnect();
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to disconnect Sage SDK session.");
+            }
+            finally
+            {
+                _session.Dispose();
+                _session = null;
+                _branchApplied = false;
+            }
+        }
     }
 }

--- a/src/Server/Infrastructure/Database/EfSageSession.cs
+++ b/src/Server/Infrastructure/Database/EfSageSession.cs
@@ -1,0 +1,75 @@
+using System.Data;
+using Microsoft.EntityFrameworkCore;
+using Server.Infrastructure.Authentication.Database;
+
+namespace Server.Infrastructure.Database;
+
+public class EfSageSession : ISageSession
+{
+    private readonly ApplicationDbContext _dbContext;
+    private bool _isConnected;
+
+    public EfSageSession(ApplicationDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public bool IsConnected => _isConnected;
+
+    public void Connect()
+    {
+        if (_isConnected)
+        {
+            return;
+        }
+
+        var connection = _dbContext.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+        {
+            _dbContext.Database.OpenConnection();
+        }
+
+        _isConnected = true;
+    }
+
+    public void Disconnect()
+    {
+        if (!_isConnected)
+        {
+            return;
+        }
+
+        var connection = _dbContext.Database.GetDbConnection();
+        if (connection.State == ConnectionState.Open)
+        {
+            _dbContext.Database.CloseConnection();
+        }
+
+        _isConnected = false;
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Disconnect();
+        }
+        catch
+        {
+            // No-op: disposal should not throw to callers.
+        }
+    }
+
+    public ISageTransaction BeginTransaction()
+    {
+        var transaction = _dbContext.Database.BeginTransaction();
+        return new EfSageTransaction(transaction);
+    }
+
+    public void SetBranch(string branchCode)
+    {
+        // Entity Framework does not support branch scoping directly. This method exists so the
+        // DatabaseContext can maintain parity with the Sage SDK behaviour. When integrating with the
+        // actual SDK, the branch context should be applied via the session APIs.
+    }
+}

--- a/src/Server/Infrastructure/Database/EfSageSessionFactory.cs
+++ b/src/Server/Infrastructure/Database/EfSageSessionFactory.cs
@@ -1,0 +1,8 @@
+using Server.Infrastructure.Authentication.Database;
+
+namespace Server.Infrastructure.Database;
+
+public class EfSageSessionFactory(ApplicationDbContext dbContext) : ISageSessionFactory
+{
+    public ISageSession CreateSession() => new EfSageSession(dbContext);
+}

--- a/src/Server/Infrastructure/Database/EfSageTransaction.cs
+++ b/src/Server/Infrastructure/Database/EfSageTransaction.cs
@@ -1,0 +1,12 @@
+using Microsoft.EntityFrameworkCore.Storage;
+
+namespace Server.Infrastructure.Database;
+
+public class EfSageTransaction(IDbContextTransaction transaction) : ISageTransaction
+{
+    public void Commit() => transaction.Commit();
+
+    public void Dispose() => transaction.Dispose();
+
+    public void Rollback() => transaction.Rollback();
+}

--- a/src/Server/Infrastructure/Database/ISageSession.cs
+++ b/src/Server/Infrastructure/Database/ISageSession.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Server.Infrastructure.Database;
+
+public interface ISageSession : IDisposable
+{
+    bool IsConnected { get; }
+
+    void Connect();
+
+    void Disconnect();
+
+    void SetBranch(string branchCode);
+
+    ISageTransaction BeginTransaction();
+}

--- a/src/Server/Infrastructure/Database/ISageSessionFactory.cs
+++ b/src/Server/Infrastructure/Database/ISageSessionFactory.cs
@@ -1,0 +1,6 @@
+namespace Server.Infrastructure.Database;
+
+public interface ISageSessionFactory
+{
+    ISageSession CreateSession();
+}

--- a/src/Server/Infrastructure/Database/ISageTransaction.cs
+++ b/src/Server/Infrastructure/Database/ISageTransaction.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Server.Infrastructure.Database;
+
+public interface ISageTransaction : IDisposable
+{
+    void Commit();
+
+    void Rollback();
+}

--- a/src/Server/Infrastructure/Database/SageSessionOptions.cs
+++ b/src/Server/Infrastructure/Database/SageSessionOptions.cs
@@ -1,0 +1,6 @@
+namespace Server.Infrastructure.Database;
+
+public class SageSessionOptions
+{
+    public string? BranchCode { get; set; }
+}

--- a/src/Server/Program.cs
+++ b/src/Server/Program.cs
@@ -27,6 +27,8 @@ builder.Services.AddIdentity<ApplicationUser, IdentityRole>()
 
 builder.Services.AddAuthorization();
 
+builder.Services.Configure<SageSessionOptions>(builder.Configuration.GetSection("Sage:Session"));
+builder.Services.AddScoped<ISageSessionFactory, EfSageSessionFactory>();
 builder.Services.AddScoped<IDatabaseContext, DatabaseContext>();
 
 builder.Services.AddScoped<IAuthAdapter, SageAuthAdapter>();

--- a/tests/Server.Tests/Infrastructure/Database/DatabaseContextTests.cs
+++ b/tests/Server.Tests/Infrastructure/Database/DatabaseContextTests.cs
@@ -1,0 +1,164 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Infrastructure.Database;
+
+namespace Server.Tests.Infrastructure.Database;
+
+public class DatabaseContextTests
+{
+    private static DatabaseContext CreateContext(
+        Mock<ISageSession> sessionMock,
+        Mock<ISageSessionFactory>? factoryMock = null,
+        SageSessionOptions? options = null,
+        Mock<ILogger<DatabaseContext>>? loggerMock = null)
+    {
+        factoryMock ??= new Mock<ISageSessionFactory>();
+        factoryMock.Setup(f => f.CreateSession()).Returns(sessionMock.Object);
+
+        options ??= new SageSessionOptions { BranchCode = "MAIN" };
+        loggerMock ??= new Mock<ILogger<DatabaseContext>>();
+
+        return new DatabaseContext(
+            loggerMock.Object,
+            factoryMock.Object,
+            Options.Create(options));
+    }
+
+    [Fact]
+    public void BeginTran_WhenSessionNotConnected_ConnectsSetsBranchAndStartsTransaction()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        var isConnected = false;
+        sessionMock.Setup(s => s.IsConnected).Returns(() => isConnected);
+        sessionMock.Setup(s => s.Connect()).Callback(() => isConnected = true);
+        sessionMock.Setup(s => s.SetBranch("MAIN"));
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+
+        var context = CreateContext(sessionMock);
+
+        context.BeginTran();
+
+        sessionMock.Verify(s => s.Connect(), Times.Once);
+        sessionMock.Verify(s => s.SetBranch("MAIN"), Times.Once);
+        sessionMock.Verify(s => s.BeginTransaction(), Times.Once);
+    }
+
+    [Fact]
+    public void BeginTran_WhenSessionAlreadyConnected_DoesNotReconnect()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        sessionMock.Setup(s => s.IsConnected).Returns(true);
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+
+        var context = CreateContext(sessionMock);
+
+        context.BeginTran();
+
+        sessionMock.Verify(s => s.Connect(), Times.Never);
+    }
+
+    [Fact]
+    public void CommitTran_CommitsAndDisposesTransaction()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        sessionMock.Setup(s => s.IsConnected).Returns(false);
+        sessionMock.Setup(s => s.Connect());
+        sessionMock.Setup(s => s.SetBranch(It.IsAny<string>()));
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+
+        var context = CreateContext(sessionMock);
+        context.BeginTran();
+
+        context.CommitTran();
+
+        transactionMock.Verify(t => t.Commit(), Times.Once);
+        transactionMock.Verify(t => t.Dispose(), Times.Once);
+        sessionMock.Verify(s => s.Disconnect(), Times.Once);
+        sessionMock.Verify(s => s.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public void CommitTran_WhenUnderlyingCommitFails_ThrowsDomainException()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        sessionMock.Setup(s => s.IsConnected).Returns(false);
+        sessionMock.Setup(s => s.Connect());
+        sessionMock.Setup(s => s.SetBranch(It.IsAny<string>()));
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+        transactionMock.Setup(t => t.Commit()).Throws(new InvalidOperationException("fail"));
+
+        var context = CreateContext(sessionMock);
+        context.BeginTran();
+
+        Action act = () => context.CommitTran();
+
+        act.Should().Throw<DomainException>().WithMessage("Unable to commit the Sage SDK transaction.*");
+        transactionMock.Verify(t => t.Dispose(), Times.Once);
+        sessionMock.Verify(s => s.Disconnect(), Times.Once);
+    }
+
+    [Fact]
+    public void RollbackTran_RollsBackAndDisposesTransaction()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        sessionMock.Setup(s => s.IsConnected).Returns(false);
+        sessionMock.Setup(s => s.Connect());
+        sessionMock.Setup(s => s.SetBranch(It.IsAny<string>()));
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+
+        var context = CreateContext(sessionMock);
+        context.BeginTran();
+
+        context.RollbackTran();
+
+        transactionMock.Verify(t => t.Rollback(), Times.Once);
+        transactionMock.Verify(t => t.Dispose(), Times.Once);
+        sessionMock.Verify(s => s.Disconnect(), Times.Once);
+        sessionMock.Verify(s => s.Dispose(), Times.Once);
+    }
+
+    [Fact]
+    public void RollbackTran_WhenUnderlyingRollbackFails_ThrowsDomainException()
+    {
+        var sessionMock = new Mock<ISageSession>();
+        var transactionMock = new Mock<ISageTransaction>();
+        sessionMock.Setup(s => s.IsConnected).Returns(false);
+        sessionMock.Setup(s => s.Connect());
+        sessionMock.Setup(s => s.SetBranch(It.IsAny<string>()));
+        sessionMock.Setup(s => s.BeginTransaction()).Returns(transactionMock.Object);
+        transactionMock.Setup(t => t.Rollback()).Throws(new InvalidOperationException("fail"));
+
+        var context = CreateContext(sessionMock);
+        context.BeginTran();
+
+        Action act = () => context.RollbackTran();
+
+        act.Should().Throw<DomainException>().WithMessage("Unable to roll back the Sage SDK transaction.*");
+        transactionMock.Verify(t => t.Dispose(), Times.Once);
+        sessionMock.Verify(s => s.Disconnect(), Times.Once);
+    }
+
+    [Fact]
+    public void BeginTran_WhenFactoryThrows_WrapsInDomainException()
+    {
+        var factoryMock = new Mock<ISageSessionFactory>();
+        factoryMock.Setup(f => f.CreateSession()).Throws(new InvalidOperationException("factory"));
+        var logger = new Mock<ILogger<DatabaseContext>>();
+        var context = new DatabaseContext(
+            logger.Object,
+            factoryMock.Object,
+            Options.Create(new SageSessionOptions()));
+
+        Action act = () => context.BeginTran();
+
+        act.Should().Throw<DomainException>().WithMessage("Unable to begin a Sage SDK transaction.*");
+    }
+}


### PR DESCRIPTION
## Summary
- wrap the database context around a Sage-style session factory to manage transactions, connection lifecycle, and branch selection
- introduce EF-based session and transaction adapters plus configuration to drive the wrapper
- add focused unit tests covering happy-path and failure scenarios for the transaction wrapper

## Testing
- ❌ `dotnet test` *(dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d092fd16c88331900ac10f2a81a4c5