### PR TITLE
Implement Sage inventory and order entry adapters

### DIFF
--- a/src/Server/Transactions/Inventory/Adapters/SageProductAdapter.cs
+++ b/src/Server/Transactions/Inventory/Adapters/SageProductAdapter.cs
@@ -1,11 +1,42 @@
+using System.Linq;
+using Server.Common.Exceptions;
 using Server.Transactions.Inventory.Models;
+using Server.Transactions.Inventory.Sdk;
 
 namespace Server.Transactions.Inventory.Adapters;
 
 public class SageProductAdapter : IProductAdapter
 {
-    public Task<IReadOnlyCollection<Product>> GetProductsAsync(CancellationToken cancellationToken)
+    private readonly ISageInventorySdk _inventorySdk;
+
+    public SageProductAdapter(ISageInventorySdk inventorySdk)
     {
-        throw new NotImplementedException("Integrate product retrieval with Sage SDK.");
+        _inventorySdk = inventorySdk;
     }
+
+    public async Task<IReadOnlyCollection<Product>> GetProductsAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var products = await _inventorySdk.GetProductsAsync(cancellationToken);
+
+            if (products is null)
+            {
+                throw new DomainException("Sage returned an empty product list.");
+            }
+
+            return products.Select(MapProduct).ToList();
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new DomainException("Unable to retrieve products from Sage.", ex);
+        }
+    }
+
+    private static Product MapProduct(SageInventoryItem item) =>
+        new(item.Code, item.Name, item.Description, item.UnitPrice, item.QuantityOnHand);
 }

--- a/src/Server/Transactions/Inventory/Sdk/ISageInventorySdk.cs
+++ b/src/Server/Transactions/Inventory/Sdk/ISageInventorySdk.cs
@@ -1,0 +1,6 @@
+namespace Server.Transactions.Inventory.Sdk;
+
+public interface ISageInventorySdk
+{
+    Task<IReadOnlyCollection<SageInventoryItem>> GetProductsAsync(CancellationToken cancellationToken);
+}

--- a/src/Server/Transactions/Inventory/Sdk/SageInventoryItem.cs
+++ b/src/Server/Transactions/Inventory/Sdk/SageInventoryItem.cs
@@ -1,0 +1,3 @@
+namespace Server.Transactions.Inventory.Sdk;
+
+public record SageInventoryItem(string Code, string Name, string Description, decimal UnitPrice, int QuantityOnHand);

--- a/src/Server/Transactions/OrderEntry/Adapters/SageOrderEntryAdapter.cs
+++ b/src/Server/Transactions/OrderEntry/Adapters/SageOrderEntryAdapter.cs
@@ -1,11 +1,59 @@
+using System.Linq;
+using Server.Common.Exceptions;
 using Server.Transactions.OrderEntry.Models;
+using Server.Transactions.OrderEntry.Sdk;
 
 namespace Server.Transactions.OrderEntry.Adapters;
 
 public class SageOrderEntryAdapter : IOrderEntryAdapter
 {
-    public Task<SalesOrder> CreateOrderAsync(SalesOrder order, CancellationToken cancellationToken)
+    private readonly ISageOrderEntrySdk _orderEntrySdk;
+
+    public SageOrderEntryAdapter(ISageOrderEntrySdk orderEntrySdk)
     {
-        throw new NotImplementedException("Integrate order creation with Sage SDK.");
+        _orderEntrySdk = orderEntrySdk;
     }
+
+    public async Task<SalesOrder> CreateOrderAsync(SalesOrder order, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var request = new SageOrderRequest(order.CustomerId, order.OrderDate, order.Lines.Select(MapLineToSdk).ToList());
+            var response = await _orderEntrySdk.CreateOrderAsync(request, cancellationToken);
+
+            if (response is null)
+            {
+                throw new DomainException("Sage returned no order response.");
+            }
+
+            var id = string.IsNullOrWhiteSpace(response.OrderNumber) ? order.Id : response.OrderNumber;
+            var status = MapStatus(response.Status);
+            var lines = response.Lines?.Select(MapLineFromSdk).ToList() ?? order.Lines.ToList();
+
+            return new SalesOrder(id, order.CustomerId, order.OrderDate, lines, status);
+        }
+        catch (DomainException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            throw new DomainException("Unable to create order in Sage.", ex);
+        }
+    }
+
+    private static SageOrderLine MapLineToSdk(SalesOrderLine line) =>
+        new(line.ProductId, line.Quantity, line.UnitPrice);
+
+    private static SalesOrderLine MapLineFromSdk(SageOrderLine line) =>
+        new(line.ProductCode, line.Quantity, line.UnitPrice);
+
+    private static string MapStatus(SageOrderStatus status) => status switch
+    {
+        SageOrderStatus.Pending => "Pending",
+        SageOrderStatus.Released => "Released",
+        SageOrderStatus.Completed => "Completed",
+        SageOrderStatus.Cancelled => "Cancelled",
+        _ => "Unknown"
+    };
 }

--- a/src/Server/Transactions/OrderEntry/Models/SalesOrder.cs
+++ b/src/Server/Transactions/OrderEntry/Models/SalesOrder.cs
@@ -1,3 +1,3 @@
 namespace Server.Transactions.OrderEntry.Models;
 
-public record SalesOrder(string Id, string CustomerId, DateTime OrderDate, IReadOnlyCollection<SalesOrderLine> Lines);
+public record SalesOrder(string Id, string CustomerId, DateTime OrderDate, IReadOnlyCollection<SalesOrderLine> Lines, string Status = "");

--- a/src/Server/Transactions/OrderEntry/Sdk/ISageOrderEntrySdk.cs
+++ b/src/Server/Transactions/OrderEntry/Sdk/ISageOrderEntrySdk.cs
@@ -1,0 +1,6 @@
+namespace Server.Transactions.OrderEntry.Sdk;
+
+public interface ISageOrderEntrySdk
+{
+    Task<SageOrderResponse> CreateOrderAsync(SageOrderRequest request, CancellationToken cancellationToken);
+}

--- a/src/Server/Transactions/OrderEntry/Sdk/SageOrderLine.cs
+++ b/src/Server/Transactions/OrderEntry/Sdk/SageOrderLine.cs
@@ -1,0 +1,3 @@
+namespace Server.Transactions.OrderEntry.Sdk;
+
+public record SageOrderLine(string ProductCode, decimal Quantity, decimal UnitPrice);

--- a/src/Server/Transactions/OrderEntry/Sdk/SageOrderRequest.cs
+++ b/src/Server/Transactions/OrderEntry/Sdk/SageOrderRequest.cs
@@ -1,0 +1,3 @@
+namespace Server.Transactions.OrderEntry.Sdk;
+
+public record SageOrderRequest(string CustomerId, DateTime OrderDate, IReadOnlyCollection<SageOrderLine> Lines);

--- a/src/Server/Transactions/OrderEntry/Sdk/SageOrderResponse.cs
+++ b/src/Server/Transactions/OrderEntry/Sdk/SageOrderResponse.cs
@@ -1,0 +1,3 @@
+namespace Server.Transactions.OrderEntry.Sdk;
+
+public record SageOrderResponse(string OrderNumber, SageOrderStatus Status, IReadOnlyCollection<SageOrderLine> Lines);

--- a/src/Server/Transactions/OrderEntry/Sdk/SageOrderStatus.cs
+++ b/src/Server/Transactions/OrderEntry/Sdk/SageOrderStatus.cs
@@ -1,0 +1,9 @@
+namespace Server.Transactions.OrderEntry.Sdk;
+
+public enum SageOrderStatus
+{
+    Pending,
+    Released,
+    Completed,
+    Cancelled
+}

--- a/src/Server/Transactions/OrderEntry/Services/OrderService.cs
+++ b/src/Server/Transactions/OrderEntry/Services/OrderService.cs
@@ -28,7 +28,7 @@ public class OrderService : IOrderService
             throw new DomainException("Orders must contain at least one line.");
         }
 
-        var order = new SalesOrder(Guid.NewGuid().ToString(), request.CustomerId, request.OrderDate, request.Lines);
+        var order = new SalesOrder(Guid.NewGuid().ToString(), request.CustomerId, request.OrderDate, request.Lines, "Pending");
 
         try
         {

--- a/tests/Server.Tests/Transactions/Inventory/SageProductAdapterTests.cs
+++ b/tests/Server.Tests/Transactions/Inventory/SageProductAdapterTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Transactions.Inventory.Adapters;
+using Server.Transactions.Inventory.Models;
+using Server.Transactions.Inventory.Sdk;
+
+namespace Server.Tests.Transactions.Inventory;
+
+public class SageProductAdapterTests
+{
+    [Fact]
+    public async Task GetProductsAsync_MapsProductsFromSdk()
+    {
+        var sdk = new Mock<ISageInventorySdk>();
+        var items = new List<SageInventoryItem>
+        {
+            new("sku-1", "Widget", "Standard widget", 10.5m, 7),
+            new("sku-2", "Gadget", "High end gadget", 25m, 2)
+        };
+
+        sdk.Setup(s => s.GetProductsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items);
+
+        var adapter = new SageProductAdapter(sdk.Object);
+
+        var products = await adapter.GetProductsAsync(CancellationToken.None);
+
+        products.Should().BeEquivalentTo(new List<Product>
+        {
+            new("sku-1", "Widget", "Standard widget", 10.5m, 7),
+            new("sku-2", "Gadget", "High end gadget", 25m, 2)
+        });
+    }
+
+    [Fact]
+    public async Task GetProductsAsync_WhenSdkThrows_ThrowsDomainException()
+    {
+        var sdk = new Mock<ISageInventorySdk>();
+        sdk.Setup(s => s.GetProductsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var adapter = new SageProductAdapter(sdk.Object);
+
+        var act = async () => await adapter.GetProductsAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Unable to retrieve products from Sage.*");
+    }
+
+    [Fact]
+    public async Task GetProductsAsync_WhenSdkReturnsNull_ThrowsDomainException()
+    {
+        var sdk = new Mock<ISageInventorySdk>();
+        sdk.Setup(s => s.GetProductsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<SageInventoryItem>?)null);
+
+        var adapter = new SageProductAdapter(sdk.Object);
+
+        var act = async () => await adapter.GetProductsAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Sage returned an empty product list.");
+    }
+}

--- a/tests/Server.Tests/Transactions/OrderEntry/SageOrderEntryAdapterTests.cs
+++ b/tests/Server.Tests/Transactions/OrderEntry/SageOrderEntryAdapterTests.cs
@@ -1,0 +1,92 @@
+using FluentAssertions;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Transactions.OrderEntry.Adapters;
+using Server.Transactions.OrderEntry.Models;
+using Server.Transactions.OrderEntry.Sdk;
+
+namespace Server.Tests.Transactions.OrderEntry;
+
+public class SageOrderEntryAdapterTests
+{
+    [Fact]
+    public async Task CreateOrderAsync_ReturnsOrderFromSdkResponse()
+    {
+        var sdk = new Mock<ISageOrderEntrySdk>();
+        var order = new SalesOrder("temp-id", "cust-1", new DateTime(2024, 1, 1),
+            new List<SalesOrderLine> { new("sku-1", 2, 15m) }, "Pending");
+        var responseLines = new List<SageOrderLine> { new("sku-1", 2, 14.5m) };
+        var response = new SageOrderResponse("SO123", SageOrderStatus.Released, responseLines);
+
+        sdk.Setup(s => s.CreateOrderAsync(It.IsAny<SageOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var adapter = new SageOrderEntryAdapter(sdk.Object);
+
+        var result = await adapter.CreateOrderAsync(order, CancellationToken.None);
+
+        result.Should().BeEquivalentTo(new SalesOrder("SO123", order.CustomerId, order.OrderDate,
+            new List<SalesOrderLine> { new("sku-1", 2, 14.5m) }, "Released"));
+
+        sdk.Verify(s => s.CreateOrderAsync(It.Is<SageOrderRequest>(r =>
+            r.CustomerId == order.CustomerId &&
+            r.OrderDate == order.OrderDate &&
+            r.Lines.Single().ProductCode == "sku-1" &&
+            r.Lines.Single().Quantity == 2 &&
+            r.Lines.Single().UnitPrice == 15m), It.IsAny<CancellationToken>()));
+    }
+
+    [Fact]
+    public async Task CreateOrderAsync_WhenSdkThrows_ThrowsDomainException()
+    {
+        var sdk = new Mock<ISageOrderEntrySdk>();
+        var order = new SalesOrder("temp", "cust-1", DateTime.UtcNow,
+            new List<SalesOrderLine> { new("sku", 1, 10m) }, "Pending");
+
+        sdk.Setup(s => s.CreateOrderAsync(It.IsAny<SageOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("failure"));
+
+        var adapter = new SageOrderEntryAdapter(sdk.Object);
+
+        var act = async () => await adapter.CreateOrderAsync(order, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Unable to create order in Sage.*");
+    }
+
+    [Fact]
+    public async Task CreateOrderAsync_WhenSdkReturnsNull_ThrowsDomainException()
+    {
+        var sdk = new Mock<ISageOrderEntrySdk>();
+        var order = new SalesOrder("temp", "cust-1", DateTime.UtcNow,
+            new List<SalesOrderLine> { new("sku", 1, 10m) }, "Pending");
+
+        sdk.Setup(s => s.CreateOrderAsync(It.IsAny<SageOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SageOrderResponse?)null);
+
+        var adapter = new SageOrderEntryAdapter(sdk.Object);
+
+        var act = async () => await adapter.CreateOrderAsync(order, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Sage returned no order response.");
+    }
+
+    [Fact]
+    public async Task CreateOrderAsync_WhenStatusUnknown_ReturnsUnknownStatus()
+    {
+        var sdk = new Mock<ISageOrderEntrySdk>();
+        var order = new SalesOrder("temp", "cust-1", DateTime.UtcNow,
+            new List<SalesOrderLine> { new("sku", 1, 10m) }, "Pending");
+        var response = new SageOrderResponse("SO999", (SageOrderStatus)999, new List<SageOrderLine>());
+
+        sdk.Setup(s => s.CreateOrderAsync(It.IsAny<SageOrderRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(response);
+
+        var adapter = new SageOrderEntryAdapter(sdk.Object);
+
+        var result = await adapter.CreateOrderAsync(order, CancellationToken.None);
+
+        result.Status.Should().Be("Unknown");
+    }
+}


### PR DESCRIPTION
## Summary
- implement Sage-based inventory and order entry adapters that wrap SDK calls and surface domain errors
- add Sage SDK abstraction contracts for inventory and sales order processing plus status mapping support
- extend sales order modeling with status defaults and cover new adapters with unit tests

## Testing
- ⚠️ `dotnet format` *(command not available in container)*
- ⚠️ `dotnet test` *(command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d092f81d5c8331ba6120481d580ac5