### PR TITLE
authentication: integrate sage auth adapter

### DIFF
--- a/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
+++ b/src/Server/Infrastructure/Authentication/Adapters/SageAuthAdapter.cs
@@ -1,11 +1,44 @@
+using Microsoft.Extensions.Logging;
+using Server.Common.Exceptions;
 using Server.Infrastructure.Authentication.Models;
+using Server.Infrastructure.Authentication.Sage;
 
 namespace Server.Infrastructure.Authentication.Adapters;
 
 public class SageAuthAdapter : IAuthAdapter
 {
-    public Task<LoginResult> LoginAsync(LoginRequest request, CancellationToken cancellationToken)
+    private readonly ISageSessionManager _sessionManager;
+    private readonly ILogger<SageAuthAdapter> _logger;
+
+    public SageAuthAdapter(ISageSessionManager sessionManager, ILogger<SageAuthAdapter> logger)
     {
-        throw new NotImplementedException("Integrate with Sage SDK authentication.");
+        _sessionManager = sessionManager;
+        _logger = logger;
+    }
+
+    public async Task<LoginResult> LoginAsync(LoginRequest request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var session = await _sessionManager.AuthenticateAsync(request.Username, request.Password, cancellationToken);
+
+            if (string.IsNullOrWhiteSpace(session.Token))
+            {
+                _logger.LogError("Sage session token was empty for {Username}", request.Username);
+                throw new SageAuthenticationException("Sage did not return a session token.");
+            }
+
+            return new LoginResult(request.Username, session.Token);
+        }
+        catch (SageAuthenticationException ex)
+        {
+            _logger.LogWarning(ex, "Invalid Sage credentials supplied for {Username}", request.Username);
+            throw new DomainException("Invalid Sage username or password.", ex);
+        }
+        catch (Exception ex) when (ex is not DomainException)
+        {
+            _logger.LogError(ex, "Failed to authenticate with Sage for {Username}", request.Username);
+            throw new DomainException("Unable to authenticate with Sage.", ex);
+        }
     }
 }

--- a/src/Server/Infrastructure/Authentication/Sage/ISageSessionManager.cs
+++ b/src/Server/Infrastructure/Authentication/Sage/ISageSessionManager.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Server.Infrastructure.Authentication.Sage;
+
+public interface ISageSessionManager
+{
+    Task<SageSession> AuthenticateAsync(string username, string password, CancellationToken cancellationToken);
+}

--- a/src/Server/Infrastructure/Authentication/Sage/SageAuthenticationException.cs
+++ b/src/Server/Infrastructure/Authentication/Sage/SageAuthenticationException.cs
@@ -1,0 +1,14 @@
+namespace Server.Infrastructure.Authentication.Sage;
+
+public class SageAuthenticationException : Exception
+{
+    public SageAuthenticationException(string message)
+        : base(message)
+    {
+    }
+
+    public SageAuthenticationException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/Server/Infrastructure/Authentication/Sage/SageSession.cs
+++ b/src/Server/Infrastructure/Authentication/Sage/SageSession.cs
@@ -1,0 +1,3 @@
+namespace Server.Infrastructure.Authentication.Sage;
+
+public record SageSession(string Token);

--- a/src/Server/Infrastructure/Authentication/Services/AuthService.cs
+++ b/src/Server/Infrastructure/Authentication/Services/AuthService.cs
@@ -27,6 +27,10 @@ public class AuthService : IAuthService
         {
             return await _authAdapter.LoginAsync(request, cancellationToken);
         }
+        catch (DomainException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to authenticate user {Username}", request.Username);

--- a/tests/Server.Tests/Infrastructure/Authentication/AuthServiceTests.cs
+++ b/tests/Server.Tests/Infrastructure/Authentication/AuthServiceTests.cs
@@ -44,4 +44,23 @@ public class AuthServiceTests
 
         await act.Should().ThrowAsync<DomainException>();
     }
+
+    [Fact]
+    public async Task LoginAsync_WhenAdapterThrowsDomainException_RethrowsSameException()
+    {
+        var adapter = new Mock<IAuthAdapter>();
+        var logger = new Mock<ILogger<AuthService>>();
+        var request = new LoginRequest("user", "password");
+        var domainException = new DomainException("Invalid Sage username or password.");
+
+        adapter.Setup(a => a.LoginAsync(request, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(domainException);
+
+        var service = new AuthService(adapter.Object, logger.Object);
+
+        var act = async () => await service.LoginAsync(request, CancellationToken.None);
+
+        var thrown = await act.Should().ThrowAsync<DomainException>();
+        thrown.Which.Should().BeSameAs(domainException);
+    }
 }

--- a/tests/Server.Tests/Infrastructure/Authentication/SageAuthAdapterTests.cs
+++ b/tests/Server.Tests/Infrastructure/Authentication/SageAuthAdapterTests.cs
@@ -1,0 +1,70 @@
+using System.Threading;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Infrastructure.Authentication.Adapters;
+using Server.Infrastructure.Authentication.Models;
+using Server.Infrastructure.Authentication.Sage;
+
+namespace Server.Tests.Infrastructure.Authentication;
+
+public class SageAuthAdapterTests
+{
+    [Fact]
+    public async Task LoginAsync_WhenSageAuthenticates_ReturnsLoginResult()
+    {
+        var sessionManager = new Mock<ISageSessionManager>();
+        var logger = new Mock<ILogger<SageAuthAdapter>>();
+        var request = new LoginRequest("user", "password");
+        var session = new SageSession("token-123");
+
+        sessionManager
+            .Setup(manager => manager.AuthenticateAsync(request.Username, request.Password, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var adapter = new SageAuthAdapter(sessionManager.Object, logger.Object);
+
+        var result = await adapter.LoginAsync(request, CancellationToken.None);
+
+        result.Should().Be(new LoginResult(request.Username, session.Token));
+    }
+
+    [Fact]
+    public async Task LoginAsync_WhenCredentialsInvalid_ThrowsDomainException()
+    {
+        var sessionManager = new Mock<ISageSessionManager>();
+        var logger = new Mock<ILogger<SageAuthAdapter>>();
+        var request = new LoginRequest("user", "bad-password");
+
+        sessionManager
+            .Setup(manager => manager.AuthenticateAsync(request.Username, request.Password, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageAuthenticationException("invalid credentials"));
+
+        var adapter = new SageAuthAdapter(sessionManager.Object, logger.Object);
+
+        var act = async () => await adapter.LoginAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Invalid Sage username or password.");
+    }
+
+    [Fact]
+    public async Task LoginAsync_WhenSageFails_ThrowsDomainException()
+    {
+        var sessionManager = new Mock<ISageSessionManager>();
+        var logger = new Mock<ILogger<SageAuthAdapter>>();
+        var request = new LoginRequest("user", "password");
+
+        sessionManager
+            .Setup(manager => manager.AuthenticateAsync(request.Username, request.Password, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"));
+
+        var adapter = new SageAuthAdapter(sessionManager.Object, logger.Object);
+
+        var act = async () => await adapter.LoginAsync(request, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>()
+            .WithMessage("Unable to authenticate with Sage.");
+    }
+}


### PR DESCRIPTION
## Summary
- implement the Sage authentication adapter using the session manager wrapper and ensure SDK failures become domain exceptions
- add Sage authentication infrastructure contracts for session handling and exceptions
- update AuthService to rethrow domain exceptions and cover the adapter with success/failure unit tests

## Testing
- `dotnet test` *(fails: dotnet command not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d092f143d083318bc97979cb563a21