### PR TITLE
accounts-receivable: integrate sage adapters

### DIFF
--- a/src/Server/Transactions/AccountsReceivable/Adapters/SageCustomerAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SageCustomerAdapter.cs
@@ -1,11 +1,42 @@
+using Server.Common.Exceptions;
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
 public class SageCustomerAdapter : ICustomerAdapter
 {
+    private readonly ISageAccountsReceivableClient _client;
+
+    public SageCustomerAdapter(ISageAccountsReceivableClient client)
+    {
+        _client = client;
+    }
+
     public Task<Customer?> GetCustomerAsync(string customerId, CancellationToken cancellationToken)
     {
-        throw new NotImplementedException("Integrate customer retrieval with Sage SDK.");
+        return GetCustomerInternalAsync(customerId, cancellationToken);
+    }
+
+    private async Task<Customer?> GetCustomerInternalAsync(string customerId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var sdkCustomer = await _client.GetCustomerAsync(customerId, cancellationToken);
+            if (sdkCustomer is null)
+            {
+                return null;
+            }
+
+            return new Customer(sdkCustomer.AccountCode, sdkCustomer.Name, sdkCustomer.EmailAddress, sdkCustomer.CreditLimit);
+        }
+        catch (SageEntityNotFoundException ex)
+        {
+            throw new NotFoundException($"Customer {customerId} was not found in Sage.", ex);
+        }
+        catch (SageSdkException ex)
+        {
+            throw new DomainException("Unable to retrieve customer from Sage.", ex);
+        }
     }
 }

--- a/src/Server/Transactions/AccountsReceivable/Adapters/SageInvoiceAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SageInvoiceAdapter.cs
@@ -1,11 +1,34 @@
+using Server.Common.Exceptions;
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
 public class SageInvoiceAdapter : IInvoiceAdapter
 {
-    public Task<Invoice> CreateInvoiceAsync(Invoice invoice, CancellationToken cancellationToken)
+    private readonly ISageAccountsReceivableClient _client;
+
+    public SageInvoiceAdapter(ISageAccountsReceivableClient client)
     {
-        throw new NotImplementedException("Integrate invoice creation with Sage SDK.");
+        _client = client;
+    }
+
+    public async Task<Invoice> CreateInvoiceAsync(Invoice invoice, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var draft = new SageInvoiceDraft(invoice.CustomerId, invoice.Amount, invoice.IssuedOn, invoice.Id, invoice.Status);
+            var sdkInvoice = await _client.CreateInvoiceAsync(draft, cancellationToken);
+
+            return new Invoice(sdkInvoice.DocumentNumber, sdkInvoice.CustomerCode, sdkInvoice.Amount, sdkInvoice.IssuedOn, sdkInvoice.Status);
+        }
+        catch (SageEntityNotFoundException ex)
+        {
+            throw new NotFoundException($"Customer {invoice.CustomerId} was not found in Sage.", ex);
+        }
+        catch (SageSdkException ex)
+        {
+            throw new DomainException("Unable to create invoice in Sage.", ex);
+        }
     }
 }

--- a/src/Server/Transactions/AccountsReceivable/Adapters/SagePaymentAdapter.cs
+++ b/src/Server/Transactions/AccountsReceivable/Adapters/SagePaymentAdapter.cs
@@ -1,11 +1,34 @@
+using Server.Common.Exceptions;
 using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
 
 namespace Server.Transactions.AccountsReceivable.Adapters;
 
 public class SagePaymentAdapter : IPaymentAdapter
 {
-    public Task<Payment> ApplyPaymentAsync(Payment payment, CancellationToken cancellationToken)
+    private readonly ISageAccountsReceivableClient _client;
+
+    public SagePaymentAdapter(ISageAccountsReceivableClient client)
     {
-        throw new NotImplementedException("Integrate payment posting with Sage SDK.");
+        _client = client;
+    }
+
+    public async Task<Payment> ApplyPaymentAsync(Payment payment, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var draft = new SagePaymentDraft(payment.InvoiceId, payment.Amount, payment.PaidOn, payment.Id);
+            var sdkPayment = await _client.ApplyPaymentAsync(draft, cancellationToken);
+
+            return new Payment(sdkPayment.ReceiptNumber, sdkPayment.InvoiceDocumentNumber, sdkPayment.Amount, sdkPayment.PaidOn);
+        }
+        catch (SageEntityNotFoundException ex)
+        {
+            throw new NotFoundException($"Invoice {payment.InvoiceId} was not found in Sage.", ex);
+        }
+        catch (SageSdkException ex)
+        {
+            throw new DomainException("Unable to post payment in Sage.", ex);
+        }
     }
 }

--- a/src/Server/Transactions/AccountsReceivable/Sdk/ISageAccountsReceivableClient.cs
+++ b/src/Server/Transactions/AccountsReceivable/Sdk/ISageAccountsReceivableClient.cs
@@ -1,0 +1,20 @@
+namespace Server.Transactions.AccountsReceivable.Sdk;
+
+public interface ISageAccountsReceivableClient
+{
+    Task<SageCustomer?> GetCustomerAsync(string customerCode, CancellationToken cancellationToken);
+
+    Task<SageInvoice> CreateInvoiceAsync(SageInvoiceDraft invoice, CancellationToken cancellationToken);
+
+    Task<SagePayment> ApplyPaymentAsync(SagePaymentDraft payment, CancellationToken cancellationToken);
+}
+
+public record SageCustomer(string AccountCode, string Name, string EmailAddress, decimal CreditLimit);
+
+public record SageInvoiceDraft(string CustomerCode, decimal Amount, DateTime IssuedOn, string ExternalReference, string Status);
+
+public record SageInvoice(string DocumentNumber, string CustomerCode, decimal Amount, DateTime IssuedOn, string Status);
+
+public record SagePaymentDraft(string InvoiceDocumentNumber, decimal Amount, DateTime PaidOn, string ExternalReference);
+
+public record SagePayment(string ReceiptNumber, string InvoiceDocumentNumber, decimal Amount, DateTime PaidOn, string Status);

--- a/src/Server/Transactions/AccountsReceivable/Sdk/SageSdkException.cs
+++ b/src/Server/Transactions/AccountsReceivable/Sdk/SageSdkException.cs
@@ -1,0 +1,23 @@
+namespace Server.Transactions.AccountsReceivable.Sdk;
+
+public class SageSdkException : Exception
+{
+    public SageSdkException(string message) : base(message)
+    {
+    }
+
+    public SageSdkException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}
+
+public class SageEntityNotFoundException : SageSdkException
+{
+    public SageEntityNotFoundException(string message) : base(message)
+    {
+    }
+
+    public SageEntityNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+}

--- a/tests/Server.Tests/Transactions/AccountsReceivable/PaymentServiceTests.cs
+++ b/tests/Server.Tests/Transactions/AccountsReceivable/PaymentServiceTests.cs
@@ -5,6 +5,7 @@ using Server.Common.Exceptions;
 using Server.Transactions.AccountsReceivable.Adapters;
 using Server.Transactions.AccountsReceivable.Models;
 using Server.Transactions.AccountsReceivable.Services;
+using Server.Transactions.AccountsReceivable.Sdk;
 
 namespace Server.Tests.Transactions.AccountsReceivable;
 
@@ -47,5 +48,30 @@ public class PaymentServiceTests
         var act = async () => await service.ApplyPaymentAsync(request, CancellationToken.None);
 
         await act.Should().ThrowAsync<DomainException>();
+    }
+
+    [Fact]
+    public async Task ApplyPaymentAsync_WithSageAdapter_MapsIdentifiers()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        var logger = Mock.Of<ILogger<PaymentService>>();
+        var request = new ApplyPaymentRequest("inv-1", 120m, new DateTime(2024, 1, 2));
+        SagePaymentDraft? capturedDraft = null;
+        client.Setup(c => c.ApplyPaymentAsync(It.IsAny<SagePaymentDraft>(), It.IsAny<CancellationToken>()))
+            .Callback<SagePaymentDraft, CancellationToken>((draft, _) => capturedDraft = draft)
+            .ReturnsAsync(new SagePayment("PAY-10", "inv-1", 120m, request.PaidOn, "Posted"));
+
+        var adapter = new SagePaymentAdapter(client.Object);
+        var service = new PaymentService(adapter, logger);
+
+        var payment = await service.ApplyPaymentAsync(request, CancellationToken.None);
+
+        capturedDraft.Should().NotBeNull();
+        capturedDraft!.InvoiceDocumentNumber.Should().Be(request.InvoiceId);
+        capturedDraft.Amount.Should().Be(request.Amount);
+        capturedDraft.PaidOn.Should().Be(request.PaidOn);
+        capturedDraft.ExternalReference.Should().NotBeNullOrWhiteSpace();
+
+        payment.Should().Be(new Payment("PAY-10", "inv-1", 120m, request.PaidOn));
     }
 }

--- a/tests/Server.Tests/Transactions/AccountsReceivable/SageCustomerAdapterTests.cs
+++ b/tests/Server.Tests/Transactions/AccountsReceivable/SageCustomerAdapterTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Transactions.AccountsReceivable.Adapters;
+using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
+
+namespace Server.Tests.Transactions.AccountsReceivable;
+
+public class SageCustomerAdapterTests
+{
+    [Fact]
+    public async Task GetCustomerAsync_MapsSageDtoToDomain()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        var sdkCustomer = new SageCustomer("100", "Acme Corp", "info@acme.test", 1200m);
+        client.Setup(c => c.GetCustomerAsync("100", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sdkCustomer);
+
+        var adapter = new SageCustomerAdapter(client.Object);
+
+        var customer = await adapter.GetCustomerAsync("100", CancellationToken.None);
+
+        customer.Should().Be(new Customer("100", "Acme Corp", "info@acme.test", 1200m));
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenSdkReturnsNull_ReturnsNull()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.GetCustomerAsync("missing", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SageCustomer?)null);
+
+        var adapter = new SageCustomerAdapter(client.Object);
+
+        var customer = await adapter.GetCustomerAsync("missing", CancellationToken.None);
+
+        customer.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenNotFound_ThrowsNotFound()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.GetCustomerAsync("missing", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageEntityNotFoundException("Customer missing."));
+
+        var adapter = new SageCustomerAdapter(client.Object);
+
+        var act = async () => await adapter.GetCustomerAsync("missing", CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetCustomerAsync_WhenSdkFails_ThrowsDomainException()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.GetCustomerAsync("100", It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageSdkException("Boom"));
+
+        var adapter = new SageCustomerAdapter(client.Object);
+
+        var act = async () => await adapter.GetCustomerAsync("100", CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+}

--- a/tests/Server.Tests/Transactions/AccountsReceivable/SageInvoiceAdapterTests.cs
+++ b/tests/Server.Tests/Transactions/AccountsReceivable/SageInvoiceAdapterTests.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Transactions.AccountsReceivable.Adapters;
+using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
+
+namespace Server.Tests.Transactions.AccountsReceivable;
+
+public class SageInvoiceAdapterTests
+{
+    [Fact]
+    public async Task CreateInvoiceAsync_MapsSageResponse()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        var issuedOn = new DateTime(2024, 1, 1);
+        var sdkInvoice = new SageInvoice("INV-100", "100", 150m, issuedOn, "Posted");
+        SageInvoiceDraft? capturedDraft = null;
+        client.Setup(c => c.CreateInvoiceAsync(It.IsAny<SageInvoiceDraft>(), It.IsAny<CancellationToken>()))
+            .Callback<SageInvoiceDraft, CancellationToken>((draft, _) => capturedDraft = draft)
+            .ReturnsAsync(sdkInvoice);
+
+        var adapter = new SageInvoiceAdapter(client.Object);
+        var invoice = new Invoice("TEMP", "100", 150m, issuedOn, "Open");
+
+        var result = await adapter.CreateInvoiceAsync(invoice, CancellationToken.None);
+
+        capturedDraft.Should().NotBeNull();
+        capturedDraft!.CustomerCode.Should().Be("100");
+        capturedDraft.Amount.Should().Be(150m);
+        capturedDraft.IssuedOn.Should().Be(issuedOn);
+        capturedDraft.Status.Should().Be("Open");
+        capturedDraft.ExternalReference.Should().Be("TEMP");
+
+        result.Should().Be(new Invoice("INV-100", "100", 150m, issuedOn, "Posted"));
+    }
+
+    [Fact]
+    public async Task CreateInvoiceAsync_WhenCustomerMissing_ThrowsNotFound()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.CreateInvoiceAsync(It.IsAny<SageInvoiceDraft>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageEntityNotFoundException("customer missing"));
+
+        var adapter = new SageInvoiceAdapter(client.Object);
+        var invoice = new Invoice("TEMP", "missing", 10m, DateTime.UtcNow, "Open");
+
+        var act = async () => await adapter.CreateInvoiceAsync(invoice, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task CreateInvoiceAsync_WhenSdkFails_ThrowsDomainException()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.CreateInvoiceAsync(It.IsAny<SageInvoiceDraft>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageSdkException("boom"));
+
+        var adapter = new SageInvoiceAdapter(client.Object);
+        var invoice = new Invoice("TEMP", "100", 10m, DateTime.UtcNow, "Open");
+
+        var act = async () => await adapter.CreateInvoiceAsync(invoice, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+}

--- a/tests/Server.Tests/Transactions/AccountsReceivable/SagePaymentAdapterTests.cs
+++ b/tests/Server.Tests/Transactions/AccountsReceivable/SagePaymentAdapterTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Moq;
+using Server.Common.Exceptions;
+using Server.Transactions.AccountsReceivable.Adapters;
+using Server.Transactions.AccountsReceivable.Models;
+using Server.Transactions.AccountsReceivable.Sdk;
+
+namespace Server.Tests.Transactions.AccountsReceivable;
+
+public class SagePaymentAdapterTests
+{
+    [Fact]
+    public async Task ApplyPaymentAsync_MapsSageResponse()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        var paidOn = new DateTime(2024, 1, 2);
+        var sdkPayment = new SagePayment("PAY-100", "INV-10", 75m, paidOn, "Posted");
+        SagePaymentDraft? capturedDraft = null;
+        client.Setup(c => c.ApplyPaymentAsync(It.IsAny<SagePaymentDraft>(), It.IsAny<CancellationToken>()))
+            .Callback<SagePaymentDraft, CancellationToken>((draft, _) => capturedDraft = draft)
+            .ReturnsAsync(sdkPayment);
+
+        var adapter = new SagePaymentAdapter(client.Object);
+        var payment = new Payment("TEMP", "INV-10", 75m, paidOn);
+
+        var result = await adapter.ApplyPaymentAsync(payment, CancellationToken.None);
+
+        capturedDraft.Should().NotBeNull();
+        capturedDraft!.InvoiceDocumentNumber.Should().Be("INV-10");
+        capturedDraft.Amount.Should().Be(75m);
+        capturedDraft.PaidOn.Should().Be(paidOn);
+        capturedDraft.ExternalReference.Should().Be("TEMP");
+
+        result.Should().Be(new Payment("PAY-100", "INV-10", 75m, paidOn));
+    }
+
+    [Fact]
+    public async Task ApplyPaymentAsync_WhenInvoiceMissing_ThrowsNotFound()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.ApplyPaymentAsync(It.IsAny<SagePaymentDraft>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageEntityNotFoundException("invoice missing"));
+
+        var adapter = new SagePaymentAdapter(client.Object);
+        var payment = new Payment("TEMP", "INV-10", 75m, DateTime.UtcNow);
+
+        var act = async () => await adapter.ApplyPaymentAsync(payment, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task ApplyPaymentAsync_WhenSdkFails_ThrowsDomainException()
+    {
+        var client = new Mock<ISageAccountsReceivableClient>();
+        client.Setup(c => c.ApplyPaymentAsync(It.IsAny<SagePaymentDraft>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new SageSdkException("boom"));
+
+        var adapter = new SagePaymentAdapter(client.Object);
+        var payment = new Payment("TEMP", "INV-10", 75m, DateTime.UtcNow);
+
+        var act = async () => await adapter.ApplyPaymentAsync(payment, CancellationToken.None);
+
+        await act.Should().ThrowAsync<DomainException>();
+    }
+}


### PR DESCRIPTION
## Summary
- add a Sage accounts receivable client abstraction and update the customer, invoice, and payment adapters to call it while mapping DTOs into domain models
- convert Sage SDK errors into domain exceptions so downstream services surface consistent failures
- extend unit coverage for adapters and services to validate mapping and exception handling paths

## Testing
- ❌ `dotnet format` *(dotnet CLI is not available in the execution environment)*
- ❌ `dotnet test` *(dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d092eb6f4483318bff589db40fde2d