### PR TITLE
ci: fix dockerfile paths in pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,8 +92,8 @@ stages:
               containerRegistry: 'acr-service-connection'
               repository: '$(backendRepository)'
               command: 'buildAndPush'
-              Dockerfile: 'src/Server/Dockerfile'
-              buildContext: 'src/Server'
+              Dockerfile: 'Dockerfile.api'
+              buildContext: '.'
               tags: |
                 $(Build.BuildNumber)
                 latest
@@ -104,8 +104,8 @@ stages:
               containerRegistry: 'acr-service-connection'
               repository: '$(frontendRepository)'
               command: 'buildAndPush'
-              Dockerfile: 'web/Dockerfile'
-              buildContext: 'web'
+              Dockerfile: 'Dockerfile.web'
+              buildContext: '.'
               tags: |
                 $(Build.BuildNumber)
                 latest


### PR DESCRIPTION
## Summary
- point the backend Docker@2 task at Dockerfile.api using the repository root as the build context so the solution and project files are available
- update the frontend Docker@2 task to consume Dockerfile.web from the repository root so the workspace lockfile can be copied during the build

## Testing
- ❌ `docker build -f Dockerfile.api -t avacare-api:test .` (Docker CLI is not available in the execution environment)
- ❌ `docker build -f Dockerfile.web -t avacare-web:test .` (Docker CLI is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d15b49c0748331af00a830f927386f